### PR TITLE
Add Reveal Data

### DIFF
--- a/src/components/MyDialog.vue
+++ b/src/components/MyDialog.vue
@@ -7,7 +7,7 @@ import {
   DialogTitle,
 } from "./ui/dialog";
 import MyDialogContent from "./MyDialogContent.vue";
-import { defineModel, useSlots } from "vue";
+import { defineModel, useSlots, ref } from "vue";
 import { useConfirmDialog } from "@vueuse/core";
 
 /**
@@ -22,12 +22,18 @@ const open = defineModel<boolean>("open", {
  * Use this pattern if you want to to open or close the Dialog
  * from within a method (e.g.: an event handler).
  **/
-type RevealData = {};
+type RevealData = Record<string, string>;
 type ConfirmData = { data: string };
 type CancelData = { data: string };
 const imperativeHandle = useConfirmDialog<RevealData, ConfirmData, CancelData>(
   open
 );
+
+imperativeHandle.onReveal((data) => {
+  revealData.value = data;
+});
+
+const revealData = ref<RevealData>({});
 
 // Here we expose the imperative API to the parent component.
 // Later this api can be accesed via the ref attribute.
@@ -67,6 +73,7 @@ const slots = useSlots();
         otherwise it will be mounted immediately 
       -->
       <MyDialogContent
+        :data="revealData"
         v-model:open="open"
         @cancel="imperativeHandle.cancel"
         @confirm="imperativeHandle.confirm"

--- a/src/components/MyDialogContent.vue
+++ b/src/components/MyDialogContent.vue
@@ -18,6 +18,11 @@
     </ul>
   </section>
 
+  <section>
+    <h2 class="font-semibold">Reveal Data</h2>
+    <pre class="rounded border p-2">{{ JSON.stringify(data, null, 2) }}</pre>
+  </section>
+
   <section class="flex flex-col space-y-2">
     <h2 class="font-semibold">Trigger Buttons:</h2>
     <!-- 
@@ -56,6 +61,14 @@ import { useQuery } from "@tanstack/vue-query";
 const open = defineModel("open", {
   type: Boolean,
   default: false,
+});
+
+type Props = {
+  data?: Record<string, string>;
+};
+
+withDefaults(defineProps<Props>(), {
+  data: () => ({}),
 });
 
 defineEmits<{


### PR DESCRIPTION
Allows to dynamically inject data via imperative handle:

```jsx
  const { data, isCanceled } = await myDialogRef.value.reveal({
    data: "Hello World",
  });
```