### PR TITLE
Add generic component 

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "tailwindcss": "^3.4.10",
     "typescript": "^5.5.3",
     "vite": "^5.4.0",
+    "vue-component-type-helpers": "^2.0.29",
     "vue-tsc": "^2.0.29"
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { Button } from "@/components/ui/button";
-import MyDialog from "@/components/MyDialog.vue";
+import MyDialogContent from "@/components/MyDialogContent.vue";
+import UnsiversalDialog from "@/components/UnsiversalDialog.vue";
 import { ref } from "vue";
 
 // Via this ref we can access the Dialog's imperative API.
-const myDialogRef = ref<InstanceType<typeof MyDialog>>();
+const myDialogRef = ref<InstanceType<typeof UnsiversalDialog>>();
 
 const handlerImperativeButtonClick = async () => {
   // Ensure the Dialog is mounted.
@@ -13,7 +14,7 @@ const handlerImperativeButtonClick = async () => {
   // Awesome! Here we have an imperative control flow.
   // We could even open multiple Dialogs in a row.
   const { data, isCanceled } = await myDialogRef.value.reveal({
-    data: "Hello World",
+    foo: "Hello World",
   });
 
   if (!isCanceled) {
@@ -26,12 +27,14 @@ const handlerImperativeButtonClick = async () => {
 
 <template>
   <div class="mx-auto max-w-80 my-8 flex flex-col space-y-4">
+    <UnsiversalDialog :content="MyDialogContent">
+      <Button>Deklarative Button Trigger</Button>
+    </UnsiversalDialog>
+
     <Button @click="handlerImperativeButtonClick">
       Imperative Button Trigger
     </Button>
 
-    <MyDialog ref="myDialogRef">
-      <Button>Deklarative Button Trigger</Button>
-    </MyDialog>
+    <UnsiversalDialog ref="myDialogRef" :content="MyDialogContent" />
   </div>
 </template>

--- a/src/components/MyDialogContent.vue
+++ b/src/components/MyDialogContent.vue
@@ -64,12 +64,12 @@ const open = defineModel("open", {
 });
 
 type Props = {
-  data?: Record<string, string>;
+  data: {
+    foo: string;
+  };
 };
 
-withDefaults(defineProps<Props>(), {
-  data: () => ({}),
-});
+defineProps<Props>();
 
 defineEmits<{
   // Declarative way

--- a/yarn.lock
+++ b/yarn.lock
@@ -1460,6 +1460,11 @@ vscode-uri@^3.0.8:
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.8.tgz#1770938d3e72588659a172d0fd4642780083ff9f"
   integrity sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==
 
+vue-component-type-helpers@^2.0.29:
+  version "2.0.29"
+  resolved "https://registry.yarnpkg.com/vue-component-type-helpers/-/vue-component-type-helpers-2.0.29.tgz#3e476321482526c63b3bbe3771eae1ad55f58a01"
+  integrity sha512-58i+ZhUAUpwQ+9h5Hck0D+jr1qbYl4voRt5KffBx8qzELViQ4XdT/Tuo+mzq8u63teAG8K0lLaOiL5ofqW38rg==
+
 vue-demi@>=0.13.0, vue-demi@>=0.14.8, vue-demi@^0.14.10:
   version "0.14.10"
   resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.14.10.tgz#afc78de3d6f9e11bf78c55e8510ee12814522f04"


### PR DESCRIPTION
This a work in Progress:

## Todo

- [ ] Add type inference support

## Usage

```vue
<script setup lang="ts">
import { Button } from "@/components/ui/button";
import UnsiversalDialog from "@/components/UnsiversalDialog.vue";
import MyDialogContent from "@/components/MyDialogContent.vue";
import { ref } from "vue";

// Via this ref we can access the Dialog's imperative API.
const myDialogRef = ref<InstanceType<typeof UnsiversalDialog>>();

const handlerImperativeButtonClick = async () => {
  // Ensure the Dialog is mounted.
  if (!myDialogRef.value) throw new Error("Dialog not mounted");

  // Awesome! Here we have an imperative control flow.
  // We could even open multiple Dialogs in a row.
  const returnData = await myDialogRef.value.reveal({
    data: 'foo'
  });

  if (!isCanceled) {
    console.log("confirmed", data);
  } else {
    console.log("canceled", data);
  }
};
</script>

<template>
  <div class="mx-auto max-w-80 my-8 flex flex-col space-y-4">

    <!-- Deklarative Usage -->
    <UnsiversalDialog :content="MyDialogContent">
      <Button>Deklarative Button Trigger</Button>
    </UnsiversalDialog>

    <!-- Imperative Usage -->
    <Button @click="handlerImperativeButtonClick">
      Imperative Button Trigger
    </Button>
    <UnsiversalDialog ref="myDialogRef" :content="MyDialogContent" />


  </div>
</template>
```